### PR TITLE
Feature Initial fuzz_target.py

### DIFF
--- a/fuzz/fuzz_target.py
+++ b/fuzz/fuzz_target.py
@@ -1,0 +1,28 @@
+import atheris
+import sys
+import os
+import json
+import torch
+from safetensors.torch import load_file, save_file
+from kernel import weight_dequant
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        fp8_path = fdp.ConsumeUnicodeNoSurrogates(50)
+        bf16_path = fdp.ConsumeUnicodeNoSurrogates(50)
+        torch.set_default_dtype(torch.bfloat16)
+        os.makedirs(bf16_path, exist_ok=True)
+        model_index_file = os.path.join(fp8_path, "model.safetensors.index.json")
+        with open(model_index_file, "r") as f:
+            model_index = json.load(f)
+        weight_map = model_index["weight_map"]
+        for tensor_name in weight_map:
+            file_name = weight_map[tensor_name]
+            file_path = os.path.join(fp8_path, file_name)
+            load_file(file_path, device="cuda")
+    except Exception as e:
+        pass
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
Hii Team

I Would like to propose integrating DeepSeek-V3 with OSS-Fuzz a continuous fuzz testing platform designed to improve the stability and security of open-source projects.

### Why Integrate DeepSeek-V3 with OSS-Fuzz?

- **Improved Stability**: OSS-Fuzz can automatically detect edge-case bugs, crashes, and security vulnerabilities in the DeepSeek-V3 codebase.
- **Enhanced Reliability**: Continuous fuzzing ensures that untrusted inputs, such as data from sensors, communication protocols, or user-defined configurations, are handled robustly.
- **Proactive Bug Fixes**: By identifying potential issues early, OSS-Fuzz helps maintain a stable and secure codebase.

This is the initial fuzz support file. If it gets merged Or Approved here from maintainer  I will make a PR in the OSS-Fuzz repository to include other files
Further, the team can also check the [OSS-Fuzz documentation](https://google.github.io/oss-fuzz/) and [Bug Disclosure Guidelines](https://google.github.io/oss-fuzz/getting-started/bug-disclosure-guidelines/).