### PR TITLE
Masking: avoid modifying tensor in-place to improve performance

### DIFF
--- a/inference/model.py
+++ b/inference/model.py
@@ -782,7 +782,7 @@ class Transformer(nn.Module):
         freqs_cis = self.freqs_cis[start_pos:start_pos+seqlen]
         mask = None
         if seqlen > 1:
-            mask = torch.full((seqlen, seqlen), float("-inf"), device=tokens.device).triu_(1)
+            mask = torch.triu(torch.full((seqlen, seqlen), float("-inf"), device=tokens.device), diagonal=1)
         for layer in self.layers:
             h = layer(h, start_pos, freqs_cis, mask)
         h = self.norm(h)[:, -1]


### PR DESCRIPTION
The new implementation avoids an unnecessary in-place modification (.triu_(1)) by directly applying the triangular mask during the tensor creation using torch.triu. This eliminates redundant memory writes and reduces overhead and is especially beneficial for large sequence lengths (seqlen) and our MoE model in general where we're masking a lot.