### PR TITLE
Update LICENSE-CODE Copyright Year from 2023 to 2023-2025

### DIFF
--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 DeepSeek
+Copyright (c) 2023-2025 DeepSeek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE-CODE` file. Currently, the file shows 2023 as the copyright year, but considering that the project was initially created in 2023, had a major release in 2024, and has continued to receive updates in 2025, this change updates the copyright statement to "2023‑2025". 

**Why this change is needed:**  
- **Accuracy:** The new date range accurately reflects the project's timeline and the ongoing updates.  
- **Consistency:** It ensures that the copyright information remains consistent with the release date and subsequent updates, improving legal clarity and overall documentation consistency.

Please review the changes and let me know if any further modifications are needed. Thank you for your consideration.
