### PR TITLE
Fix Linear Layer Bias Initialization

### DIFF
--- a/inference/model.py
+++ b/inference/model.py
@@ -185,7 +185,7 @@ class Linear(nn.Module):
         else:
             self.register_parameter("scale", None)
         if bias:
-            self.bias = nn.Parameter(torch.empty(self.part_out_features))
+            self.bias = nn.Parameter(torch.empty(out_features))
         else:
             self.register_parameter("bias", None)
 


### PR DESCRIPTION
## Description
Fixed bias initialization in the [Linear](cci:2://file:///d:/Github/DeepSeek-V3/inference/model.py:163:0-201:48) class by using `out_features` instead of the undefined `self.part_out_features`. This fix ensures proper bias initialization for all linear layers in the model.

## Changes Made
- Modified `Linear.__init__` to use `out_features` parameter for bias tensor initialization
- Ensures consistency with parent and child classes (ColumnParallelLinear and RowParallelLinear)

## Why This Change is Needed
The previous implementation tried to access `self.part_out_features` which is only defined in child classes (ColumnParallelLinear), causing potential issues when the Linear class is used directly. Using `out_features` is the correct approach as it's always available and matches the weight tensor's output dimension.

## Testing Done
- Model initialization works correctly with bias enabled
- Compatible with both standard and parallel linear layers
- No impact on existing functionality
## Checklist
- [x] Code follows the project's coding style
- [x] Changes are backward compatible
- [x] No new dependencies added