### PR TITLE
Update requirements.txt

### DIFF
--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.4.1
-triton==3.0.0
+torch==2.6.0
+triton==3.2.0
 transformers==4.46.3
 safetensors==0.4.5


### PR DESCRIPTION
The current pip library does not provide version 2.4.1 'touch' and version 3.0.0 'triton', and the 'requirements.txt' file has been updated to a minimum to meet the current pip installation requirements