### PR TITLE
Fix incorrect comment in linear function regarding weight.element_size()

### DIFF
--- a/inference/model.py
+++ b/inference/model.py
@@ -143,8 +143,8 @@ def linear(x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] =
         quantization-aware computations depending on the input parameters.
 
     Notes:
-        - If `weight` is quantized (e.g., `element_size() == 1`), a dequantized version 
-          is used for computation.
+        - If `weight` is in a higher precision format (e.g., float32 or bfloat16), then `element_size() > 1`, and the original
+          weight tensor is used for computation.
         - If `gemm_impl == "bf16"`, dequantization and a `bf16` GEMM operation are applied.
         - For other cases, the function applies quantization to `x` and uses `fp8_gemm` for computation.
     """


### PR DESCRIPTION
This PR fixes issue #579 by correcting the comment in the linear function. The previous comment incorrectly stated that element_size() > 1 indicates quantization. In addition, the phrase "dequantized version" was misleading, as no dequantization occurs when element_size() > 1. The updated comment now accurately reflects that element_size() > 1 refers to higher precision formats like float32 and bfloat16, and that the original weight tensor is directly used in computations.