### PR TITLE
fix an args description.

### DIFF
--- a/inference/kernel.py
+++ b/inference/kernel.py
@@ -87,7 +87,7 @@ def weight_dequant(x: torch.Tensor, s: torch.Tensor, block_size: int = 128) -> t
 
     Args:
         x (torch.Tensor): The quantized weight tensor of shape (M, N).
-        s (torch.Tensor): The scale tensor of shape (M, N).
+        s (torch.Tensor): The scale tensor of shape (M//block_size, N//block_size).
         block_size (int, optional): The block size to use for dequantization. Defaults to 128.
 
     Returns:


### PR DESCRIPTION
The scale factor matrix is constructed with the step of each block. 

This is shown in how it is used:
 s = tl.load(s_ptr + pid_m * n + pid_n)

And how it is calculated:
In class Linear(nn.Module):
        if self.weight.element_size() == 1:
            scale_out_features = (out_features + block_size - 1) // block_size
            scale_in_features = (in_features + block_size - 1) // block_size
            self.weight.scale = self.scale = nn.Parameter(torch.empty(scale_out_features, scale_in_features, dtype=torch.float32))