### PR TITLE
Update kernel.py

### DIFF
--- a/inference/kernel.py
+++ b/inference/kernel.py
@@ -1,9 +1,21 @@
+import sys
+import platform
+if platform.system() == "Windows":
+    sys.exit("Triton is not supported on Windows. Please use Linux or a Linux-based Docker container.")
+
 from typing import Tuple
 
-import torch
-import triton
-import triton.language as tl
-from triton import Config
+try:
+    import torch
+except ImportError:
+    sys.exit("PyTorch is required for this project. Please install torch >=2.1.0.")
+
+try:
+    import triton
+    import triton.language as tl
+    from triton import Config
+except ImportError:
+    sys.exit("Triton is required for this project. Please install it on a supported Linux system with CUDA.")
 
 
 @triton.jit


### PR DESCRIPTION
The update to kernel.py is correct for user experience: it now checks for both torch and triton and provides clear error messages if either is missing, in addition to the platform check. All other errors are expected on Windows due to the lack of Triton and CUDA support.

Summary of what was fixed:

Added a try/except block for the torch import, so users get a clear message if PyTorch is missing.
Maintained the platform and Triton checks for user-friendly errors.