### PR TITLE
Fix broken TensorRT-LLM link to deepseekv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ For comprehensive step-by-step instructions on running DeepSeek-V3 with LMDeploy
 
 ### 6.4 Inference with TRT-LLM (recommended)
 
-[TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) now supports the DeepSeek-V3 model, offering precision options such as BF16 and INT4/INT8 weight-only. Support for FP8 is currently in progress and will be released soon. You can access the custom branch of TRTLLM specifically for DeepSeek-V3 support through the following link to experience the new features directly: https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/deepseek_v3. 
+[TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) now supports the DeepSeek-V3 model, offering precision options such as BF16 and INT4/INT8 weight-only. Support for FP8 is currently in progress and will be released soon. You can access the custom branch of TRTLLM specifically for DeepSeek-V3 support through the following link to experience the new features directly: [https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/deepseek_v3](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/deepseek_v3). 
 
 
 ### 6.5 Inference with vLLM (recommended)

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ For comprehensive step-by-step instructions on running DeepSeek-V3 with LMDeploy
 
 ### 6.4 Inference with TRT-LLM (recommended)
 
-[TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) now supports the DeepSeek-V3 model, offering precision options such as BF16 and INT4/INT8 weight-only. Support for FP8 is currently in progress and will be released soon. You can access the custom branch of TRTLLM specifically for DeepSeek-V3 support through the following link to experience the new features directly: [https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/deepseek_v3](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/deepseek_v3). 
+[TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) now supports the DeepSeek-V3 model, offering precision options such as BF16 and INT4/INT8 weight-only. Support for FP8 is currently in progress and will be released soon. You can access the custom branch of TRTLLM specifically for DeepSeek-V3 support through the following link to experience the new features directly:  [https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/deepseek_v3](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/models/core/deepseek_v3). 
 
 
 ### 6.5 Inference with vLLM (recommended)


### PR DESCRIPTION
Fix broken TensorRT-LLM link to deepseekv3 examples