### PR TITLE
feat: add mobile-compatible requirements (CPU-only)

### DIFF
--- a/inference/mobile/__init__.py
+++ b/inference/mobile/__init__.py
@@ -1,0 +1,3 @@
+# DeepSeek Mobile Inference Module
+# Placeholder for mobile-specific inference utilities
+

--- a/inference/mobile/setup.sh
+++ b/inference/mobile/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# DeepSeek Mobile Setup Script
+# Run: bash setup.sh
+
+echo "Installing DeepSeek mobile dependencies..."
+pip install torch --index-url https://download.pytorch.org/whl/cpu
+pip install transformers safetensors
+echo "Done. Run: python generate.py"
+

--- a/inference/requirements-mobile.txt
+++ b/inference/requirements-mobile.txt
@@ -1,0 +1,9 @@
+# DeepSeek Mobile Dependencies
+# CPU-only versions for Android/Termux, iOS/iSH, HarmonyOS
+
+torch>=2.0.0  # CPU version (no CUDA)
+transformers>=4.40.0
+safetensors>=0.4.0
+# Note: triton removed (NVIDIA GPU only, not available on ARM/Android)
+# Mobile users should pip install torch --index-url https://download.pytorch.org/whl/cpu
+


### PR DESCRIPTION
## What
Adds requirements-mobile.txt for Android/Termux, iOS/iSH, and HarmonyOS.

## Why
triton is NVIDIA GPU only and not available on ARM/mobile devices. This file provides CPU-only alternatives.

## Changes
- Removed triton dependency
- Added mobile installation instructions
- Relaxed version pins for broader mobile compatibility