### PR TITLE
docs: update Twitter link to X in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     src="https://img.shields.io/badge/Discord-DeepSeek%20AI-7289da?logo=discord&logoColor=white&color=7289da"/></a>
   <a href="https://github.com/deepseek-ai/DeepSeek-V2/blob/main/figures/qr.jpeg?raw=true"><img alt="Wechat"
     src="https://img.shields.io/badge/WeChat-DeepSeek%20AI-brightgreen?logo=wechat&logoColor=white"/></a>
-  <a href="https://twitter.com/deepseek_ai"><img alt="Twitter Follow"
+  <a href="https://x.com/deepseek_ai"><img alt="Twitter Follow"
     src="https://img.shields.io/badge/Twitter-deepseek_ai-white?logo=x&logoColor=white"/></a>
   <br>
   <a href="https://github.com/deepseek-ai/DeepSeek-V3/blob/main/LICENSE-CODE"><img alt="Code License"


### PR DESCRIPTION
Replace twitter.com with x.com to reflect the platform rebrand.