### PR TITLE
fix: validate inference and conversion edge cases

### DIFF
--- a/inference/fp8_cast_bf16.py
+++ b/inference/fp8_cast_bf16.py
@@ -9,6 +9,7 @@ from safetensors.torch import load_file, save_file
 
 from kernel import weight_dequant
 
+
 def main(fp8_path, bf16_path):
     """
     Converts FP8 weights to BF16 and saves the converted weights.
@@ -18,24 +19,28 @@ def main(fp8_path, bf16_path):
     model index file to reflect the changes.
 
     Args:
-    fp8_path (str): The path to the directory containing the FP8 weights and model index file.
-    bf16_path (str): The path to the directory where the converted BF16 weights will be saved.
+        fp8_path (str): The directory containing the FP8 weights and model index file.
+        bf16_path (str): The directory where the converted BF16 weights will be saved.
 
     Raises:
-    KeyError: If a required scale_inv tensor is missing for a weight.
+        ValueError: If the input and output directories refer to the same location.
 
     Notes:
-    - The function assumes that the FP8 weights are stored in safetensor files.
-    - The function caches loaded safetensor files to optimize memory usage.
-    - The function updates the model index file to remove references to scale_inv tensors.
+        - The function assumes that the FP8 weights are stored in safetensor files.
+        - The function caches loaded safetensor files to optimize memory usage.
+        - The function updates the model index file to remove scale_inv references.
     """
+    if os.path.realpath(fp8_path) == os.path.realpath(bf16_path):
+        raise ValueError("Input and output directories must be different")
+
     torch.set_default_dtype(torch.bfloat16)
     os.makedirs(bf16_path, exist_ok=True)
     model_index_file = os.path.join(fp8_path, "model.safetensors.index.json")
-    with open(model_index_file, "r") as f:
+    with open(model_index_file, encoding="utf-8") as f:
         model_index = json.load(f)
-    weight_map = model_index["weight_map"]
-    
+    weight_map = model_index["weight_map"].copy()
+    metadata = model_index.get("metadata", {})
+
     # Cache for loaded safetensor files
     loaded_files = {}
     fp8_weight_names = []
@@ -66,7 +71,7 @@ def main(fp8_path, bf16_path):
         file_name = os.path.basename(safetensor_file)
         current_state_dict = load_file(safetensor_file, device="cuda")
         loaded_files[file_name] = current_state_dict
-        
+
         new_state_dict = {}
         for weight_name, weight in current_state_dict.items():
             if weight_name.endswith("_scale_inv"):
@@ -79,29 +84,32 @@ def main(fp8_path, bf16_path):
                     fp8_weight_names.append(weight_name)
                     new_state_dict[weight_name] = weight_dequant(weight, scale_inv)
                 except KeyError:
-                    print(f"Warning: Missing scale_inv tensor for {weight_name}, skipping conversion")
+                    print(
+                        f"Warning: Missing scale_inv tensor for {weight_name}, "
+                        "skipping conversion"
+                    )
                     new_state_dict[weight_name] = weight
             else:
                 new_state_dict[weight_name] = weight
-                
+
         new_safetensor_file = os.path.join(bf16_path, file_name)
         save_file(new_state_dict, new_safetensor_file)
-        
+
         # Memory management: keep only the 2 most recently used files
         if len(loaded_files) > 2:
             oldest_file = next(iter(loaded_files))
             del loaded_files[oldest_file]
             torch.cuda.empty_cache()
-    
+
     # Update model index
     new_model_index_file = os.path.join(bf16_path, "model.safetensors.index.json")
     for weight_name in fp8_weight_names:
         scale_inv_name = f"{weight_name}_scale_inv"
         if scale_inv_name in weight_map:
             weight_map.pop(scale_inv_name)
-    with open(new_model_index_file, "w") as f:
-        json.dump({"metadata": {}, "weight_map": weight_map}, f, indent=2)
-        
+    with open(new_model_index_file, "w", encoding="utf-8") as f:
+        json.dump({"metadata": metadata, "weight_map": weight_map}, f, indent=2)
+
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -109,4 +117,3 @@ if __name__ == "__main__":
     parser.add_argument("--output-bf16-hf-path", type=str, required=True)
     args = parser.parse_args()
     main(args.input_fp8_hf_path, args.output_bf16_hf_path)
-    

--- a/inference/generate.py
+++ b/inference/generate.py
@@ -48,8 +48,19 @@ def generate(
     Returns:
         List[List[int]]: A list of lists containing the generated tokens for each sequence.
     """
+    if not prompt_tokens:
+        raise ValueError("At least one prompt is required")
+    if any(not tokens for tokens in prompt_tokens):
+        raise ValueError("Prompts must contain at least one token")
+    if max_new_tokens < 0:
+        raise ValueError("max_new_tokens must be non-negative")
+
     prompt_lens = [len(t) for t in prompt_tokens]
-    assert max(prompt_lens) <= model.max_seq_len, f"Prompt length exceeds model maximum sequence length (max_seq_len={model.max_seq_len})"
+    if max(prompt_lens) > model.max_seq_len:
+        raise ValueError(
+            "Prompt length exceeds model maximum sequence length "
+            f"(max_seq_len={model.max_seq_len})"
+        )
     total_len = min(model.max_seq_len, max_new_tokens + max(prompt_lens))
     tokens = torch.full((len(prompt_tokens), total_len), -1, dtype=torch.long, device="cuda")
     for i, t in enumerate(prompt_tokens):
@@ -97,6 +108,25 @@ def main(
         max_new_tokens (int, optional): Maximum number of new tokens to generate. Defaults to 100.
         temperature (float, optional): Temperature for sampling. Defaults to 1.0.
     """
+    if max_new_tokens < 0:
+        raise ValueError("max_new_tokens must be non-negative")
+
+    prompts = None
+    if not interactive:
+        if not input_file:
+            raise ValueError("input_file is required in batch mode")
+        with open(input_file, encoding="utf-8") as f:
+            prompts = [line.strip() for line in f if line.strip()]
+        if not prompts:
+            raise ValueError("Input file contains no non-empty prompts")
+
+    with open(config, encoding="utf-8") as f:
+        args = ModelArgs(**json.load(f))
+    if prompts is not None and len(prompts) > args.max_batch_size:
+        raise ValueError(
+            f"Number of prompts exceeds maximum batch size ({args.max_batch_size})"
+        )
+
     world_size = int(os.getenv("WORLD_SIZE", "1"))
     rank = int(os.getenv("RANK", "0"))
     local_rank = int(os.getenv("LOCAL_RANK", "0"))
@@ -109,8 +139,6 @@ def main(
     torch.set_default_dtype(torch.bfloat16)
     torch.set_num_threads(8)
     torch.manual_seed(965)
-    with open(config) as f:
-        args = ModelArgs(**json.load(f))
     print(args)
     with torch.device("cuda"):
         model = Transformer(args)
@@ -122,13 +150,21 @@ def main(
         messages = []
         while True:
             if world_size == 1:
-                prompt = input(">>> ")
-            elif rank == 0:
-                prompt = input(">>> ")
-                objects = [prompt]
-                dist.broadcast_object_list(objects, 0)
+                try:
+                    prompt = input(">>> ")
+                except EOFError:
+                    print()
+                    break
             else:
-                objects = [None]
+                if rank == 0:
+                    try:
+                        prompt = input(">>> ")
+                    except EOFError:
+                        print()
+                        prompt = "/exit"
+                    objects = [prompt]
+                else:
+                    objects = [None]
                 dist.broadcast_object_list(objects, 0)
                 prompt = objects[0]
             if prompt == "/exit":
@@ -137,17 +173,34 @@ def main(
                 messages.clear()
                 continue
             messages.append({"role": "user", "content": prompt})
-            prompt_tokens = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
-            completion_tokens = generate(model, [prompt_tokens], max_new_tokens, tokenizer.eos_token_id, temperature)
+            prompt_tokens = tokenizer.apply_chat_template(
+                messages, add_generation_prompt=True
+            )
+            completion_tokens = generate(
+                model,
+                [prompt_tokens],
+                max_new_tokens,
+                tokenizer.eos_token_id,
+                temperature,
+            )
             completion = tokenizer.decode(completion_tokens[0], skip_special_tokens=True)
             print(completion)
             messages.append({"role": "assistant", "content": completion})
     else:
-        with open(input_file) as f:
-            prompts = [line.strip() for line in f.readlines()]
-        assert len(prompts) <= args.max_batch_size, f"Number of prompts exceeds maximum batch size ({args.max_batch_size})"
-        prompt_tokens = [tokenizer.apply_chat_template([{"role": "user", "content": prompt}], add_generation_prompt=True) for prompt in prompts]
-        completion_tokens = generate(model, prompt_tokens, max_new_tokens, tokenizer.eos_token_id, temperature)
+        assert prompts is not None
+        prompt_tokens = [
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": prompt}], add_generation_prompt=True
+            )
+            for prompt in prompts
+        ]
+        completion_tokens = generate(
+            model,
+            prompt_tokens,
+            max_new_tokens,
+            tokenizer.eos_token_id,
+            temperature,
+        )
         completions = tokenizer.batch_decode(completion_tokens, skip_special_tokens=True)
         for prompt, completion in zip(prompts, completions):
             print("Prompt:", prompt)
@@ -170,8 +223,6 @@ if __name__ == "__main__":
         --max-new-tokens (int, optional): Maximum number of new tokens to generate. Defaults to 200.
         --temperature (float, optional): Temperature for sampling. Defaults to 0.2.
 
-    Raises:
-        AssertionError: If neither input-file nor interactive mode is specified.
     """
     parser = ArgumentParser()
     parser.add_argument("--ckpt-path", type=str, required=True)
@@ -181,5 +232,15 @@ if __name__ == "__main__":
     parser.add_argument("--max-new-tokens", type=int, default=200)
     parser.add_argument("--temperature", type=float, default=0.2)
     args = parser.parse_args()
-    assert args.input_file or args.interactive, "Either input-file or interactive mode must be specified"
-    main(args.ckpt_path, args.config, args.input_file, args.interactive, args.max_new_tokens, args.temperature)
+    if not args.input_file and not args.interactive:
+        parser.error("either --input-file or --interactive must be specified")
+    if args.max_new_tokens < 0:
+        parser.error("--max-new-tokens must be non-negative")
+    main(
+        args.ckpt_path,
+        args.config,
+        args.input_file,
+        args.interactive,
+        args.max_new_tokens,
+        args.temperature,
+    )

--- a/tests/test_inference_edge_cases.py
+++ b/tests/test_inference_edge_cases.py
@@ -1,0 +1,138 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, path, stubs):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, stubs):
+        spec.loader.exec_module(module)
+    return module
+
+
+def torch_stubs():
+    torch = types.ModuleType("torch")
+    distributed = types.ModuleType("torch.distributed")
+    torch.distributed = distributed
+    torch.Tensor = object
+    torch.bfloat16 = "bfloat16"
+    torch.inference_mode = lambda: (lambda function: function)
+    torch.set_default_dtype = lambda _dtype: None
+    return torch, distributed
+
+
+class GenerateEdgeCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch, distributed = torch_stubs()
+        transformers = types.ModuleType("transformers")
+        transformers.AutoTokenizer = object
+        safetensors = types.ModuleType("safetensors")
+        safetensors_torch = types.ModuleType("safetensors.torch")
+        safetensors_torch.load_model = lambda *_args, **_kwargs: None
+        model = types.ModuleType("model")
+        model.Transformer = object
+        model.ModelArgs = object
+        cls.module = load_module(
+            "generate_under_test",
+            ROOT / "inference" / "generate.py",
+            {
+                "torch": torch,
+                "torch.distributed": distributed,
+                "transformers": transformers,
+                "safetensors": safetensors,
+                "safetensors.torch": safetensors_torch,
+                "model": model,
+            },
+        )
+
+    def test_generate_rejects_empty_batch(self):
+        model = types.SimpleNamespace(max_seq_len=16)
+        with self.assertRaisesRegex(ValueError, "At least one prompt"):
+            self.module.generate(model, [], 1, 0)
+
+    def test_generate_rejects_empty_token_sequence(self):
+        model = types.SimpleNamespace(max_seq_len=16)
+        with self.assertRaisesRegex(ValueError, "at least one token"):
+            self.module.generate(model, [[]], 1, 0)
+
+    def test_generate_rejects_negative_token_limit(self):
+        model = types.SimpleNamespace(max_seq_len=16)
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            self.module.generate(model, [[1]], -1, 0)
+
+    def test_generate_rejects_prompt_over_model_limit(self):
+        model = types.SimpleNamespace(max_seq_len=2)
+        with self.assertRaisesRegex(ValueError, "maximum sequence length"):
+            self.module.generate(model, [[1, 2, 3]], 1, 0)
+
+    def test_batch_mode_rejects_file_without_prompts(self):
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as input_file:
+            input_file.write("  \n\n")
+            input_file.flush()
+            with self.assertRaisesRegex(ValueError, "no non-empty prompts"):
+                self.module.main("unused", "unused", input_file.name, interactive=False)
+
+
+class Fp8ConversionEdgeCaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch, _ = torch_stubs()
+        torch.cuda = types.SimpleNamespace(empty_cache=lambda: None)
+        safetensors = types.ModuleType("safetensors")
+        safetensors_torch = types.ModuleType("safetensors.torch")
+        safetensors_torch.load_file = lambda *_args, **_kwargs: {}
+        safetensors_torch.save_file = lambda *_args, **_kwargs: None
+        tqdm = types.ModuleType("tqdm")
+        tqdm.tqdm = lambda values: values
+        kernel = types.ModuleType("kernel")
+        kernel.weight_dequant = lambda weight, _scale: weight
+        cls.module = load_module(
+            "fp8_cast_bf16_under_test",
+            ROOT / "inference" / "fp8_cast_bf16.py",
+            {
+                "torch": torch,
+                "safetensors": safetensors,
+                "safetensors.torch": safetensors_torch,
+                "tqdm": tqdm,
+                "kernel": kernel,
+            },
+        )
+
+    def test_rejects_in_place_conversion(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(ValueError, "must be different"):
+                self.module.main(directory, directory)
+
+    def test_preserves_model_index_metadata(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source"
+            output = Path(directory) / "output"
+            source.mkdir()
+            index = {
+                "metadata": {"total_size": 123},
+                "weight_map": {"model.weight": "model-00001.safetensors"},
+            }
+            (source / "model.safetensors.index.json").write_text(
+                json.dumps(index), encoding="utf-8"
+            )
+
+            self.module.main(str(source), str(output))
+
+            converted_index = json.loads(
+                (output / "model.safetensors.index.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(converted_index, index)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate empty prompt batches, empty token sequences, token limits, and batch input before CUDA/distributed initialization
- handle interactive EOF cleanly across both single-process and distributed inference
- prevent in-place FP8-to-BF16 conversion and preserve model index metadata
- add lightweight regression tests for the new edge-case handling

## Tests

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v`
- `PYTHONPYCACHEPREFIX=/tmp/deepseek-v3-pycache python3 -m compileall -q inference tests`
- `git diff --check`